### PR TITLE
Fix playground db.sqlite unlink error

### DIFF
--- a/epicshop/post-set-playground.js
+++ b/epicshop/post-set-playground.js
@@ -1,19 +1,29 @@
 import { existsSync } from 'node:fs'
+import { unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 import { execa } from 'execa'
 
-const seedPath = join(
-	process.env.EPICSHOP_PLAYGROUND_DEST_DIR,
-	'src',
-	'db',
-	'seed.ts',
-)
+const playgroundDir = process.env.EPICSHOP_PLAYGROUND_DEST_DIR
+const seedPath = join(playgroundDir, 'src', 'db', 'seed.ts')
+
+// Delete the database file if it exists to prevent EBUSY errors when switching playgrounds
+const dbPath = join(playgroundDir, 'db.sqlite')
+if (existsSync(dbPath)) {
+	console.log('Deleting existing database file...')
+	try {
+		await unlink(dbPath)
+		console.log('Database file deleted successfully')
+	} catch (error) {
+		console.warn('Failed to delete database file:', error.message)
+		// Continue anyway - the seed script will also try to delete it
+	}
+}
 
 if (existsSync(seedPath)) {
 	console.log('Running seed script...')
 	try {
 		await execa('npx', ['tsx', seedPath], {
-			cwd: process.env.EPICSHOP_PLAYGROUND_DEST_DIR,
+			cwd: playgroundDir,
 			stdio: 'inherit',
 		})
 		console.log('Seed script completed successfully')


### PR DESCRIPTION
Proactively delete the SQLite database file (`db.sqlite`) before seeding to prevent `EBUSY` errors when switching playgrounds.

When switching playgrounds, the `db.sqlite` file could remain locked by the previous process, causing an 'EBUSY: resource busy or locked' error when the seed script attempts to delete or recreate it. This change ensures the file is deleted early, mitigating the lock.