### PR TITLE
Fix minor typos in exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 - JavaScript/TypeScript experience
 - Node.js experience
-- [Advanced MCP Features](https://www.epicai.pro/mcp-fundamentals) or equivalent
+- [MCP Fundamentals](https://www.epicai.pro/mcp-fundamentals) or equivalent
   experience.
 
 ## Pre-workshop Resources

--- a/exercises/03.sampling/01.problem.simple/README.mdx
+++ b/exercises/03.sampling/01.problem.simple/README.mdx
@@ -45,7 +45,7 @@ The `maxTokens` option references the max tokens the model should return.
 
 <callout-warning>
 	The `system prompt` + `messages` + `OUTPUT MESSAGE` can't exceed the context
-	window size of the model you're user is using.
+	window size of the model your user is using.
 </callout-warning>
 
 This step will help you get comfortable with the basic request/response flow for

--- a/exercises/05.changes/03.problem.subscriptions/README.mdx
+++ b/exercises/05.changes/03.problem.subscriptions/README.mdx
@@ -1,6 +1,6 @@
 # Subscriptions
 
-👨‍💼 When people use our EpicMe journaling MCP, they want the LLM they're using to always have the latest version of their jounraling data. Exposing subscriptions for resources (like a particular entry, tag, or video) allows clients to be notified of changes to specific resources the LLM is using in its context or the client may be using for other purposes.
+👨‍💼 When people use our EpicMe journaling MCP, they want the LLM they're using to always have the latest version of their journaling data. Exposing subscriptions for resources (like a particular entry, tag, or video) allows clients to be notified of changes to specific resources the LLM is using in its context or the client may be using for other purposes.
 
 To make this possible, our MCP server needs to support **resource subscriptions**. This means clients can subscribe to updates for specific resources, and the server will notify them when those resources change.
 


### PR DESCRIPTION
## Fix typo in sampling exercise documentation

**What changed:**
- Fixed grammatical error in exercise 3.1 and 5.3
- Fixed name of prerequisite, since it was linking the MCP Fundamentals project

**Impact:**
- Documentation clarity improvement
- No functional changes to code or exercises