### PR TITLE
docs(advanced-tools): MCP documentation link for tool annotations

### DIFF
--- a/exercises/01.advanced-tools/README.mdx
+++ b/exercises/01.advanced-tools/README.mdx
@@ -119,7 +119,7 @@ Clients can use annotations to:
 
 ### Learn More 📜
 
-For a full list of available annotations and their meanings, see the [official MCP documentation on tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations).
+For a full list of available annotations and their meanings, see the [official MCP documentation on tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/schema#toolannotations).
 
 ## Structured Output and Output Schemas
 


### PR DESCRIPTION
The original link doesn't include information about tool annotation schema, but the reference does.

<img width="244" height="669" alt="image" src="https://github.com/user-attachments/assets/dfd675be-2b3b-4abe-a647-07e14b8f9e1c" />
