### PR TITLE
fix(elicitations): 2.1 Fix typo and expected deletion message

### DIFF
--- a/exercises/02.elicitation/01.problem/src/tools.ts
+++ b/exercises/02.elicitation/01.problem/src/tools.ts
@@ -290,12 +290,12 @@ export async function initializeTools(agent: EpicMeMCP) {
 			const existingTag = await agent.db.getTag(id)
 			invariant(existingTag, `Tag ID "${id}" not found`)
 
-			// 🐨 first check whether the client has the elicitInput capability, if it does then:
+			// 🐨 first check whether the client has the elicitation capability, if it does then:
 			// 🐨 Use agent.server.server.elicitInput to ask the user to confirm deletion of the tag.
 			//    - The message should be: `Are you sure you want to delete tag "${existingTag.name}" (ID: ${id})?`
 			//    - The requestedSchema should be an object with a boolean property "confirmed".
 			// 🐨 If the user does not confirm, return structuredContent with success: false and the tag.
-			//    - Also return content with a text block saying "Tag deletion cancelled", the tag resource link, and the structuredContent.
+			//    - Also return content with a text block saying `Deleting tag "${existingTag.name}" (ID: ${id}) rejected by the user.`, the tag resource link, and the structuredContent.
 
 			await agent.db.deleteTag(id)
 			const structuredContent = { success: true, tag: existingTag }


### PR DESCRIPTION
For Elicitations, problem 1.

## Changes

- In the solution, the capability property is `elicitations` not `elicitInput` which is the method name.
- In addition, the solution has a more verbose message than what's specified in the comment.