### PR TITLE
fix(sampling): 3.1 remove state comment in index.ts

### DIFF
--- a/exercises/03.sampling/01.problem.simple/src/index.ts
+++ b/exercises/03.sampling/01.problem.simple/src/index.ts
@@ -7,7 +7,6 @@ import { initializeTools } from './tools.ts'
 
 export class EpicMeMCP {
 	db: DB
-	// 🐨 add a state object with a loggingLevel property set to 'info'
 	server = new McpServer(
 		{
 			name: 'epicme',


### PR DESCRIPTION
Kody suggests adding a state object to the EpicMeMCP class with a loggingLevel property set to 'info'. However, this isn't used or in the solution/tests.