### PR TITLE
test: stabilize wrapped video progress check

### DIFF
--- a/exercises/05.changes/01.solution.list-changed/src/index.test.ts
+++ b/exercises/05.changes/01.solution.list-changed/src/index.test.ts
@@ -390,85 +390,92 @@ test('Advanced Sampling', async () => {
 	await new Promise((resolve) => setTimeout(resolve, 100))
 })
 
-test('Progress notification: create_wrapped_video (mock)', async () => {
-	await using setup = await setupClient()
-	const { client } = setup
+test(
+	'Progress notification: create_wrapped_video (mock)',
+	{ timeout: 10_000 },
+	async () => {
+		await using setup = await setupClient()
+		const { client } = setup
 
-	const progressDeferred = await deferred<any>()
-	client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
-		progressDeferred.resolve(notification)
-	})
-
-	// Ensure the tool is enabled by creating a tag and an entry first
-	await client.callTool({
-		name: 'create_tag',
-		arguments: {
-			name: faker.lorem.word(),
-			description: faker.lorem.sentence(),
-		},
-	})
-	await client.callTool({
-		name: 'create_entry',
-		arguments: {
-			title: faker.lorem.words(3),
-			content: faker.lorem.paragraphs(2),
-		},
-	})
-
-	// Call the tool with mockTime: 500
-	const progressToken = faker.string.uuid()
-	const createVideoResult = await client.callTool({
-		name: 'create_wrapped_video',
-		arguments: {
-			mockTime: 500,
-		},
-		_meta: {
-			progressToken,
-		},
-	})
-
-	// Verify the tool call completed successfully
-	expect(
-		createVideoResult.structuredContent,
-		'🚨 create_wrapped_video should return structured content',
-	).toBeDefined()
-
-	let progressNotif
-	try {
-		progressNotif = await Promise.race([
-			progressDeferred.promise,
-			new Promise((_, reject) =>
-				setTimeout(() => reject(new Error('timeout')), 2000),
-			),
-		])
-	} catch {
-		throw new Error(
-			'🚨 Did not receive progress notification for create_wrapped_video (mock). Make sure your tool sends progress updates when running in mock mode.',
+		const progressDeferred = await deferred<any>()
+		client.setNotificationHandler(
+			ProgressNotificationSchema,
+			(notification) => {
+				progressDeferred.resolve(notification)
+			},
 		)
-	}
 
-	expect(
-		progressNotif,
-		'🚨 Did not receive progress notification for create_wrapped_video (mock).',
-	).toBeDefined()
+		// Ensure the tool is enabled by creating a tag and an entry first
+		await client.callTool({
+			name: 'create_tag',
+			arguments: {
+				name: faker.lorem.word(),
+				description: faker.lorem.sentence(),
+			},
+		})
+		await client.callTool({
+			name: 'create_entry',
+			arguments: {
+				title: faker.lorem.words(3),
+				content: faker.lorem.paragraphs(2),
+			},
+		})
 
-	expect(
-		typeof progressNotif.params.progress,
-		'🚨 progress should be a number',
-	).toBe('number')
-	expect(
-		progressNotif.params.progress,
-		'🚨 progress should be a number between 0 and 1',
-	).toBeGreaterThanOrEqual(0)
-	expect(
-		progressNotif.params.progress,
-		'🚨 progress should be a number between 0 and 1',
-	).toBeLessThanOrEqual(1)
-	expect(
-		progressNotif.params.progressToken,
-		'🚨 progressToken should match the token sent in the tool call',
-	).toBe(progressToken)
-})
+		// Call the tool with mockTime: 500
+		const progressToken = faker.string.uuid()
+		const createVideoResult = await client.callTool({
+			name: 'create_wrapped_video',
+			arguments: {
+				mockTime: 500,
+			},
+			_meta: {
+				progressToken,
+			},
+		})
+
+		// Verify the tool call completed successfully
+		expect(
+			createVideoResult.structuredContent,
+			'🚨 create_wrapped_video should return structured content',
+		).toBeDefined()
+
+		let progressNotif
+		try {
+			progressNotif = await Promise.race([
+				progressDeferred.promise,
+				new Promise((_, reject) =>
+					setTimeout(() => reject(new Error('timeout')), 2000),
+				),
+			])
+		} catch {
+			throw new Error(
+				'🚨 Did not receive progress notification for create_wrapped_video (mock). Make sure your tool sends progress updates when running in mock mode.',
+			)
+		}
+
+		expect(
+			progressNotif,
+			'🚨 Did not receive progress notification for create_wrapped_video (mock).',
+		).toBeDefined()
+
+		expect(
+			typeof progressNotif.params.progress,
+			'🚨 progress should be a number',
+		).toBe('number')
+		expect(
+			progressNotif.params.progress,
+			'🚨 progress should be a number between 0 and 1',
+		).toBeGreaterThanOrEqual(0)
+		expect(
+			progressNotif.params.progress,
+			'🚨 progress should be a number between 0 and 1',
+		).toBeLessThanOrEqual(1)
+		expect(
+			progressNotif.params.progressToken,
+			'🚨 progressToken should match the token sent in the tool call',
+		).toBe(progressToken)
+	},
+)
 
 test('Cancellation support: create_wrapped_video (mock)', async () => {
 	await using setup = await setupClient()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- give the subprocess-backed wrapped-video progress integration test a scoped 10-second timeout
- preserve the existing 2-second notification assertion and progress-token checks

## Context
Main deploy run https://github.com/epicweb-dev/advanced-mcp-features/actions/runs/30418877470 exhausted Vitest's default 5-second test deadline under runner load. Local baseline passed 10/10 in about one second, indicating timing sensitivity rather than a behavioral failure.

## Verification
- focused progress test: 10/10 repeated runs passed
- full list-changed solution suite: 7/7 passed
- scoped lint and workspace typecheck passed
- PR CI passed on all platforms after retrying an unrelated transient npm registry ETARGET
- squash-merged as `7653c8b3b423f95307240b793eb51d752a3f1ff4`
- [main deploy workflow](https://github.com/epicweb-dev/advanced-mcp-features/actions/runs/30448132033): Setup, Test, and Deploy all succeeded
- [deployed workshop](https://epicweb-dev-advanced-mcp-features.fly.dev/) and health check both return successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-429f62dd-024a-4790-8a68-7ec4e73800d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-429f62dd-024a-4790-8a68-7ec4e73800d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

